### PR TITLE
Add processChunksWith et al

### DIFF
--- a/src/Streamly/Internal/System/Process.hs
+++ b/src/Streamly/Internal/System/Process.hs
@@ -145,6 +145,9 @@ unfoldManyEither ::(IsStream t, Monad m) =>
     Unfold m a b -> t m (Either a a) -> t m (Either b b)
 unfoldManyEither u m = fromStreamD $ unfoldManyEitherD u (toStreamD m)
 
+-- TODO Add the path of the executable and the PID of the process to the
+-- exception info to aid debugging.
+
 -- | Represents the failure exit code of a process.
 --
 -- @since 0.1.0

--- a/src/Streamly/System/Process.hs
+++ b/src/Streamly/System/Process.hs
@@ -6,6 +6,8 @@
 -- Stability   : experimental
 -- Portability : GHC
 --
+-- Use OS processes as stream transformation functions.
+--
 -- This module provides functions to run operating system processes as stream
 -- source, sink or transformation functions. Thus OS processes can be used in
 -- the same way as Haskell functions and all the streaming combinators in

--- a/src/Streamly/System/Process.hs
+++ b/src/Streamly/System/Process.hs
@@ -7,16 +7,19 @@
 -- Portability : GHC
 --
 -- This module provides functions to run operating system processes as stream
--- source, sink or transformation functions. Thus OS processes can be used like
--- regular Haskell stream functions and all the streaming combinators in
--- streamly can be used to combine them.
+-- source, sink or transformation functions. Thus OS processes can be used in
+-- the same way as Haskell functions and all the streaming combinators in
+-- streamly can be used to combine them. This allows you to seamlessly
+-- integrate external programs into your Haskell program.
+--
+-- We recommend that you use Streamly threads instead of system processes where
+-- possible as they have a simpler programming model and processes have a
+-- larger performance overhead.
 --
 -- = Process Attributes
 --
--- The default attributes of the new process created by the APIs in this module
--- are described below:
---
--- * The following attributes are inherited from the parent process:
+-- As usual, in the new process the following attributes are inherited from the
+-- parent process:
 --
 --     * Current working directory
 --     * Environment
@@ -25,9 +28,6 @@
 --     * Process uid and gid
 --     * Signal handlers
 --     * Terminal (Session)
---
--- See the documentation of specific functions for the behavior of @stdin@,
--- @stdout@ and @stderr@ file descriptors.
 --
 -- = Shell Programming
 --

--- a/streamly-process.cabal
+++ b/streamly-process.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.2
 name:                streamly-process
 version:             0.1.0
-synopsis:            Streaming interfaces for system processes
+synopsis:            Use OS processes as stream transformation functions
 description:
   Connect system processes with Haskell functions or with each other,
   like Unix pipes, using streams.

--- a/test/Streamly/System/Process.hs
+++ b/test/Streamly/System/Process.hs
@@ -486,6 +486,9 @@ main = do
     createExecutables
     hspec $ do
         describe "Streamly.System.Process" $ do
+            -- XXX Add a test for garbage collection case. Also check whether
+            -- the process is really gone after exception or gc.
+            --
             -- Keep the tests in dependency order so that we test the basic
             -- things first.
             describe "processChunks'" $ do


### PR DESCRIPTION
* Lower level combinators that use a process Config to run the process.
* Also updated some docs
* Added a (currently unused) function for a different cleanup on exception than on normal exit, will be used when streamly bracket changes allow a different function to be run on exceptions.