### PR TITLE
Make stdin available to non-pipe APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* `toChunks` and `toBytes` now make the stdin available to the process being
+  executed.
+
 ## 0.2.0.1 (Mar 2022)
 
 * Fix the test suite.

--- a/default.nix
+++ b/default.nix
@@ -47,7 +47,7 @@ let haskellPackages =
                         #  } {})
                         (let src = fetchGit {
                             url = "git@github.com:composewell/streamly.git";
-                            rev = "d6b509ef919abf03a0b878e6bbf9521778d3d929";
+                            rev = "cbccb7777792cb4bf8dd8716929f4e28ea6cf718";
                         }; in super.callCabal2nix "streamly" src {})
                         (old:
                           { librarySystemDepends =
@@ -62,7 +62,7 @@ let haskellPackages =
                       nixpkgs.haskell.lib.overrideCabal
                         (let src = fetchGit {
                             url = "git@github.com:composewell/streamly.git";
-                            rev = "d6b509ef919abf03a0b878e6bbf9521778d3d929";
+                            rev = "cbccb7777792cb4bf8dd8716929f4e28ea6cf718";
                         }; in super.callCabal2nix "streamly-core" "${src}/core" {})
                         (old:
                           { librarySystemDepends =

--- a/src/Streamly/Internal/System/Process.hs
+++ b/src/Streamly/Internal/System/Process.hs
@@ -54,9 +54,7 @@ module Streamly.Internal.System.Process
 
     -- * Generation
     , toBytes
-    , toBytes'
     , toChunks
-    , toChunks'
     , toChars
     , toLines
     , toString
@@ -65,12 +63,18 @@ module Streamly.Internal.System.Process
 
     -- * Transformation
     , pipeBytes
-    , pipeBytes'
-    , pipeChars
-    , pipeChunksWith
     , pipeChunks
-    , pipeChunks'With
+    , pipeChars
+
+    -- * Stderr
+    , toBytes' -- toBytesEither ?
+    , toChunks'
+    , pipeBytes'
     , pipeChunks'
+
+    -- * Helpers
+    , pipeChunksWith
+    , pipeChunks'With
 
     -- * Deprecated
     , processBytes

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,9 +5,9 @@ packages:
 extra-deps:
 - unicode-data-0.3.0
 - git: https://github.com/composewell/streamly
-  commit: "d6b509ef919abf03a0b878e6bbf9521778d3d929"
+  commit: "cbccb7777792cb4bf8dd8716929f4e28ea6cf718"
 - git: https://github.com/composewell/streamly
-  commit: "d6b509ef919abf03a0b878e6bbf9521778d3d929"
+  commit: "cbccb7777792cb4bf8dd8716929f4e28ea6cf718"
   subdirs:
     - core
 

--- a/streamly-process.cabal
+++ b/streamly-process.cabal
@@ -82,7 +82,7 @@ library
     , exceptions        >= 0.8   && < 0.11
     , process           >= 1.0   && < 1.7
     -- Uses internal APIs
-    , streamly          == 0.8.2.*
+    , streamly          == 0.9.0.*
   if !os(windows)
     build-depends:
       unix              >= 2.5   && < 2.8
@@ -108,7 +108,7 @@ benchmark Benchmark.System.Process
     , directory         >= 1.2.2 && < 1.4
     , process           >= 1.0   && < 1.7
     -- Uses internal APIs
-    , streamly          == 0.8.2.*
+    , streamly          == 0.9.0.*
 
   if flag(fusion-plugin) && !impl(ghc < 8.6)
     build-depends:
@@ -139,4 +139,4 @@ test-suite Test.System.Process
     , process           >= 1.0   && < 1.7
     , QuickCheck        >= 2.10  && < 2.15
     -- Uses internal APIs
-    , streamly          == 0.8.2.*
+    , streamly          == 0.9.0.*


### PR DESCRIPTION
    Earlier we were passing a nil input stream to APIs like `toBytes`. That
    made the behavior weird for programs like "cat" which read from stdin.
    Because they would just silently exit instead of reading their input
    from stdin. We should either error out in such cases or allow stdin to
    be read. We did the latter in this commit.
