### PR TITLE
Remove buffering from the pipe file handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Remove buffering from the pipe chunked APIs.
+
 ## 0.3.1 (Dec 2023)
 
 * Allow streamly-0.10.0 and streamly-core-0.2.0

--- a/src/DocTestProcess.hs
+++ b/src/DocTestProcess.hs
@@ -2,6 +2,7 @@
 
 >>> :set -XFlexibleContexts
 >>> :set -XScopedTypeVariables
+>>> :set -Wno-deprecations
 >>> import Data.Char (toUpper)
 >>> import Data.Function ((&))
 >>> import qualified Streamly.Console.Stdio as Stdio
@@ -13,7 +14,8 @@
 
 For APIs that have not been released yet.
 
->>> import qualified Streamly.Internal.Console.Stdio as Stdio (putChars, putChunks)
+>>> import Streamly.Internal.System.IO (defaultChunkSize)
+>>> import qualified Streamly.Internal.Console.Stdio as Stdio (putChars, putChunks, readChunks)
 >>> import qualified Streamly.Internal.FileSystem.Dir as Dir (readFiles)
 >>> import qualified Streamly.Internal.System.Process as Process
 >>> import qualified Streamly.Internal.Unicode.Stream as Unicode (lines)

--- a/src/Streamly/Internal/System/Process.hs
+++ b/src/Streamly/Internal/System/Process.hs
@@ -805,6 +805,8 @@ processBytes = pipeBytes
 -- For control over the input buffer use your own chunking and chunk based
 -- APIs.
 --
+-- NOTE: This API uses UTF-8 encoding.
+--
 -- >>> :{
 --    Process.toChars "echo" ["hello world"]
 --  & Process.pipeChars "tr" ["[a-z]", "[A-Z]"]
@@ -982,6 +984,8 @@ toChunks = toChunksWith id
 -- | @toChars path args@ runs the executable specified by @path@ using @args@
 -- as arguments and returns the output of the process as a stream of chars.
 --
+-- NOTE: This API uses UTF-8 encoding.
+--
 -- Raises 'ProcessFailure' exception in case of failure.
 --
 -- Definition:
@@ -999,6 +1003,8 @@ toChars path args = toBytes path args & Unicode.decodeUtf8
 -- | @toLines f path args@ runs the executable specified by @path@ using @args@
 -- as arguments and folds the output of the process at line breaks, using the
 -- fold @f@, to return a stream of folded lines.
+--
+-- NOTE: This API uses UTF-8 encoding.
 --
 -- Raises 'ProcessFailure' exception in case of failure.
 --
@@ -1021,6 +1027,8 @@ toLines f path args = toChars path args & Unicode.lines f
 
 -- | @toString path args@ runs the executable specified by @path@ using @args@
 -- as arguments and folds the entire output of the process as a single string.
+--
+-- NOTE: This API uses UTF-8 encoding.
 --
 -- Definition:
 --

--- a/src/Streamly/System/Process.hs
+++ b/src/Streamly/System/Process.hs
@@ -38,7 +38,9 @@
 --
 -- >>> :{
 --    Process.toBytes "echo" ["hello world"]
---  & Unicode.decodeLatin1 & fmap toUpper & Unicode.encodeLatin1
+--  & Unicode.decodeLatin1
+--  & fmap toUpper
+--  & Unicode.encodeLatin1
 --  & Stream.fold Stdio.write
 --  :}
 --  HELLO WORLD
@@ -72,6 +74,15 @@
 --    Dir.readFiles "."
 --  & Stream.parConcatMap id grep
 --  & Stream.fold Stdio.writeChunks
+-- :}
+--
+-- = Running Interactive Programs (e.g. ghci)
+--
+-- >>> :{
+-- ghci =
+--  Stdio.readChunks
+--   & Process.pipeChunks "ghci" []
+--   & Stdio.putChunks
 -- :}
 --
 -- = Experimental APIs


### PR DESCRIPTION
The underlying pipe file handles should not use buffering at all. Any type of buffering can be easily achieved using stream operations.